### PR TITLE
Deletion of pwm

### DIFF
--- a/system/API/Output.py
+++ b/system/API/Output.py
@@ -13,6 +13,9 @@ class Output :
 	def __init__(self, bus: SMBus) :
 		self._pwm: PWM = PWM(bus)
 
+	def __del__(self) :
+		del(self._pwm)
+
 	def setDutyCycle(self, location: Motor, value: int) -> None:
 		# Can use this function to discretize
 		self._pwm.setDutyCycle(location, value)

--- a/system/API/modules/PWM.py
+++ b/system/API/modules/PWM.py
@@ -69,6 +69,7 @@ class PWM :
 		self._initializePWM()
 
 	def __del__(self) :
+		self.setAllDutyCycle(0)
 		self._bus.write_byte_data(self._address, _Registers.MODE1.value, 0x10) # Re-enable sleep mode
 
 	def setDutyCycle(self, location: Motor, value: int) -> None:
@@ -77,3 +78,7 @@ class PWM :
 				(value & 0xf00)>>8)	# Write upper 4 bits to OFF_H
 			self._bus.write_byte_data(self._address, PWM.LocationRegisterMap[location][1].value, \
 				value & 0x0ff)	# Write lower 8 bits to OFF_L
+
+	def setAllDutyCycle(self, value: int) -> None:
+		for motor in LocationRegisterMap.keys() :
+			setDutyCycle(motor, value)

--- a/system/API/modules/PWM.py
+++ b/system/API/modules/PWM.py
@@ -80,5 +80,5 @@ class PWM :
 				value & 0x0ff)	# Write lower 8 bits to OFF_L
 
 	def setAllDutyCycle(self, value: int) -> None:
-		for motor in LocationRegisterMap.keys() :
+		for motor in PWM.LocationRegisterMap.keys() :
 			setDutyCycle(motor, value)

--- a/system/API/modules/PWM.py
+++ b/system/API/modules/PWM.py
@@ -81,4 +81,4 @@ class PWM :
 
 	def setAllDutyCycle(self, value: int) -> None:
 		for motor in PWM.LocationRegisterMap.keys() :
-			setDutyCycle(motor, value)
+			self.setDutyCycle(motor, value)


### PR DESCRIPTION
Closes #27
Issue reopened because of an error in testing. setAllDutyCycle in PWM.py was not tested properly and had some errors.